### PR TITLE
troubleshoot: Improve locale detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ SPDX-License-Identifier: MPL-2.0
 
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- `utf8-troubleshoot`: improve available locale detection
+- `utf8-troubleshoot`: display raw results from C libraries
+
 ## 1.0.1.0
 
 GHC 8.10 compatibility and a new troubleshooting tool.

--- a/app/utf8-troubleshoot/Main.hs
+++ b/app/utf8-troubleshoot/Main.hs
@@ -11,7 +11,7 @@ module Main (main) where
 
 import Prelude hiding (print, putStr, putStrLn)
 
-import Control.Exception.Safe (handleIO, tryIO)
+import Control.Exception.Safe (catchIO, tryIO)
 import Control.Monad (filterM, forM_)
 import Data.List (sort)
 import Data.Version (showVersion)
@@ -118,7 +118,8 @@ showLocales = do
         showLocaleList (lines out)
       Left _ -> do
         listDir "/usr/lib/locale"
-        handleIO (\_ -> pure ()) $ listFile "/usr/lib/locale/locale-archive"
+        listFile "/usr/lib/locale/locale-archive" `catchIO` \e ->
+          putStrLn $ "<error>: " <> show e
   where
     showLocaleList :: [String] -> IO ()
     showLocaleList locales =
@@ -141,8 +142,8 @@ showLocales = do
     listFile path = doesPathExist path >>= \case
       False -> putStrLn $ "  * " <> path <> " does not exist."
       True -> do
-        out <- readProcess "localedef" ["--list", path] ""
         putStrLn $ "  * " <> path <> ":"
+        out <- readProcess "localedef" ["--list", path] ""
         showLocaleList (lines out)
 
 

--- a/app/utf8-troubleshoot/Main.hs
+++ b/app/utf8-troubleshoot/Main.hs
@@ -77,7 +77,7 @@ showCbits = do
 #if defined(HAVE_LIBCHARSET)
       enc <- c_libcharsetEncoding >>= peekCAString
       putStrLn $ "  * libcharset:locale_charset = " <> enc
-#elif
+#else
       putStrLn $ "  * No libcharset."
 #endif
 
@@ -86,7 +86,7 @@ showCbits = do
 #if defined(HAVE_LANGINFO_H)
       enc <- c_langinfoEncoding >>= peekCAString
       putStrLn $ "  * langinfo.h:nl_langinfo(CODESET) = " <> enc
-#elif
+#else
       putStrLn $ "  * No <langinfo.h>."
 #endif
 

--- a/app/utf8-troubleshoot/Main.hs
+++ b/app/utf8-troubleshoot/Main.hs
@@ -105,12 +105,7 @@ showEnv = do
     putStrLn "# Environment"
     mapM_ showEnvVar
       [ "LANG"
-      , "LC_COLLATE"
       , "LC_CTYPE"
-      , "LC_MESSAGES"
-      , "LC_MONETARY"
-      , "LC_NUMERIC"
-      , "LC_TIME"
       , "LC_ALL="
       ]
 

--- a/app/utf8-troubleshoot/Main.hs
+++ b/app/utf8-troubleshoot/Main.hs
@@ -2,7 +2,10 @@
 --
 -- SPDX-License-Identifier: MPL-2.0
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
+
+#include <HsBaseConfig.h>
 
 module Main (main) where
 
@@ -12,7 +15,9 @@ import Control.Exception.Safe (handleIO, tryIO)
 import Control.Monad (filterM, forM_)
 import Data.List (sort)
 import Data.Version (showVersion)
+import Foreign.C.String (CString, peekCAString)
 import GHC.IO.Encoding (getLocaleEncoding, initLocaleEncoding)
+import GHC.IO.Encoding.Iconv (localeEncodingName)
 import GHC.Show (showLitString)
 import System.Directory (doesDirectoryExist, doesPathExist, listDirectory)
 import System.Environment (lookupEnv)
@@ -59,6 +64,41 @@ showGhc = do
     getLocaleEncoding >>= \e -> putStrLn $ "  * locale encoding = " <> show e
     hGetEncoding stdout >>= \e -> putStrLn $ "  * stdout = " <> show e
     hGetEncoding stderr >>= \e -> putStrLn $ "  * stderr = " <> show e
+
+showCbits :: IO ()
+showCbits = do
+    putStrLn "# C bits"
+    putStrLn $ "  * localeEncodingName = " <> localeEncodingName
+    showLibcharset
+    showLanginfoh
+  where
+    showLibcharset :: IO ()
+    showLibcharset = do
+#if defined(HAVE_LIBCHARSET)
+      enc <- c_libcharsetEncoding >>= peekCAString
+      putStrLn $ "  * libcharset:locale_charset = " <> enc
+#elif
+      putStrLn $ "  * No libcharset."
+#endif
+
+    showLanginfoh :: IO ()
+    showLanginfoh = do
+#if defined(HAVE_LANGINFO_H)
+      enc <- c_langinfoEncoding >>= peekCAString
+      putStrLn $ "  * langinfo.h:nl_langinfo(CODESET) = " <> enc
+#elif
+      putStrLn $ "  * No <langinfo.h>."
+#endif
+
+#if defined(HAVE_LIBCHARSET)
+foreign import ccall unsafe "libcharsetEncoding"
+  c_libcharsetEncoding :: IO CString
+#endif
+
+#if defined(HAVE_LANGINFO_H)
+foreign import ccall unsafe "langinfoEncoding"
+  c_langinfoEncoding :: IO CString
+#endif
 
 showEnv :: IO ()
 showEnv = do
@@ -116,5 +156,6 @@ main :: IO ()
 main = do
   showSystem
   showGhc
+  showCbits
   showEnv
   showLocales

--- a/app/utf8-troubleshoot/Main.hs
+++ b/app/utf8-troubleshoot/Main.hs
@@ -149,9 +149,9 @@ showLocales = do
 
     listDir :: FilePath -> IO ()
     listDir path = doesPathExist path >>= \case
-      False -> putStrLn $ "  * " <> path <> " does not exist."
+      False -> putStrLn $ "  * " <> path <> " does not exist"
       True -> doesDirectoryExist path >>= \case
-        False -> putStrLn $ "  * " <> path <> " is not a directory."
+        False -> putStrLn $ "  * " <> path <> " is not a directory"
         True -> do
           putStrLn $ "  * " <> path <> ":"
           ls <- listDirectory path >>= filterM (doesDirectoryExist . (path </>))
@@ -159,7 +159,7 @@ showLocales = do
 
     listFile :: FilePath -> IO ()
     listFile path = doesPathExist path >>= \case
-      False -> putStrLn $ "  * " <> path <> " does not exist."
+      False -> putStrLn $ "  * " <> path <> " does not exist"
       True -> do
         putStrLn $ "  * " <> path <> ":"
         out <- readProcess "localedef" ["--list", path] ""

--- a/app/utf8-troubleshoot/cbits/locale.c
+++ b/app/utf8-troubleshoot/cbits/locale.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+//
+// SPDX-License-Identifier: MPL-2.0
+
 #define INLINE
 
 #include <HsBase.h>

--- a/app/utf8-troubleshoot/cbits/locale.c
+++ b/app/utf8-troubleshoot/cbits/locale.c
@@ -1,0 +1,21 @@
+#define INLINE
+
+#include <HsBase.h>
+
+#if !defined(mingw32_HOST_OS)
+
+#if defined(HAVE_LIBCHARSET)
+#include <libcharset.h>
+const char* libcharsetEncoding(void) {
+  return locale_charset();
+}
+#endif
+
+#if defined(HAVE_LANGINFO_H)
+#include <langinfo.h>
+const char* langinfoEncoding(void) {
+  return nl_langinfo(CODESET);
+}
+#endif
+
+#endif

--- a/app/utf8-troubleshoot/cbits/locale.c
+++ b/app/utf8-troubleshoot/cbits/locale.c
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-#define INLINE
-
-#include <HsBase.h>
+#include <HsBaseConfig.h>
 
 #if !defined(mingw32_HOST_OS)
 

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ executables:
       - filepath
       - process
       - safe-exceptions
+      - th-env
 
 tests:
   with-utf8-test:

--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,8 @@ executables:
     source-dirs: app/utf8-troubleshoot
     main: Main.hs
 
+    c-sources: app/utf8-troubleshoot/cbits/locale.c
+
     dependencies:
       - base
       - directory

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,9 @@ executables:
     dependencies:
       - base
       - directory
+      - filepath
+      - process
+      - safe-exceptions
 
 tests:
   with-utf8-test:

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,3 +4,6 @@
 
 resolver: lts-14.25
 packages: [.]
+
+extra-deps:
+  - th-env-0.1.0.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: th-env-0.1.0.1@sha256:960423c1951e3c36ba62d5286c7fa859095d41a309c4ea13c2d90abfe5d35bca,1171
+    pantry-tree:
+      size: 370
+      sha256: bfbb41d856bdb5c678f678a4af9ee4a96ad9aa73460444f12d952e9901df2940
+  original:
+    hackage: th-env-0.1.0.1
 snapshots:
 - completed:
     size: 524163


### PR DESCRIPTION
* Use `localectl list-locales` if possible.
* Otherwise list `/usr/lib/locale` and try to use `localedef` to list
  `/usr/lib/locale/locale-archive`.
* Do not bother with `/usr/share/locale` as, it turns out, it is only used
  for localisations by third-party programs on Linux. Strangely, macOS
  seems to have actual locale definitions in there, but this tool is
  mostly aimed at Linux, since macOS installations are pretty uniform.