### PR TITLE
Make it build with ghc-9.8

### DIFF
--- a/with-utf8.cabal
+++ b/with-utf8.cabal
@@ -48,9 +48,9 @@ library
       lib
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
-      base >=4.10 && <4.19
+      base >=4.10 && <4.20
     , safe-exceptions ==0.1.*
-    , text >=0.7 && <2.1
+    , text >=0.7 && <2.2
   default-language: Haskell2010
 
 executable utf8-troubleshoot
@@ -63,12 +63,12 @@ executable utf8-troubleshoot
   c-sources:
       app/utf8-troubleshoot/cbits/locale.c
   build-depends:
-      base >=4.10 && <4.19
+      base >=4.10 && <4.20
     , directory >=1.2.5.0 && <1.4
     , filepath >=1.0 && <1.5
     , process >=1.0.1.1 && <1.7
     , safe-exceptions
-    , text >=0.7 && <2.1
+    , text >=0.7 && <2.2
     , th-env >=0.1.0.0 && <0.2
   default-language: Haskell2010
 
@@ -89,7 +89,7 @@ test-suite with-utf8-test
       tasty-discover:tasty-discover
   build-depends:
       HUnit
-    , base >=4.10 && <4.19
+    , base >=4.10 && <4.20
     , deepseq
     , hedgehog
     , safe-exceptions
@@ -97,7 +97,7 @@ test-suite with-utf8-test
     , tasty-hedgehog
     , tasty-hunit
     , temporary
-    , text >=0.7 && <2.1
+    , text >=0.7 && <2.2
     , unix
     , with-utf8
   default-language: Haskell2010


### PR DESCRIPTION
Builds fine, but get a warning in the tests:
```
test/Test/Utf8/ReadWrite.hs:25:1: error: [GHC-45102]
    Ambiguous module name ‘Data.Text.IO.Utf8’.
    it was found in multiple packages: text-2.1 with-utf8-1.0.2.4
   |
25 | import qualified Data.Text.IO.Utf8 as Utf8
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
SInce this is only a version bump, I would appreciate a Hackage metadata update.