### PR TITLE
[Chore] Update "actions/checkout"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ jobs:
   validate:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: xrefcheck
         run: nix run github:serokell/xrefcheck
@@ -40,7 +40,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - id: set-matrix
       run: echo "matrix=$(nix eval --json .#ghc-matrix.x86_64-linux)" >> $GITHUB_OUTPUT
@@ -54,7 +54,7 @@ jobs:
       matrix: ${{fromJson(needs.ghc-versions.outputs.matrix)}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: build
         run: nix build -L .#checks.x86_64-linux.ghc${{ matrix.ghc }}:build-all --keep-going


### PR DESCRIPTION
Problem: node16 is now deprecated and github-runner provided by nixpkgs
no longer supports this runtime. However, "actions/checkout@v3" uses
this runtime.

Solution: Update CI pipeline to use "actions/checkout@v4".
