### PR TITLE
Support GHC-9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## 1.1.0.0
+
+### Changed
+
+- Allow newer versions of base and text to support GHC up to 9.8.
+- Deprecate Data.Text.IO.Utf8.
+
+
 ## 1.0.2.4
 
 ### Changed
@@ -8,7 +16,6 @@
 - Allow base 4.17, 4.18 (GHC 9.4, 9.6).
 - Allow text<2.1
 
-## 1.0.2.2
 
 ## 1.0.2.3
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ error due to encoding issues.
 If you are going to read a text file (to be precise, if you are going to open
 a file in text mode), you’ll probably use `withFile`, `openFile`, or `readFile`.
 Grab the first two from `System.IO.Utf8` or the latter from `Data.Text.IO.Utf8`.
+Starting from `text-2.1`, `Data.Text.IO.Utf8` is available in the `text` package
+itself, hence this module in `with-utf8` is now deprecated.
 
 _Note: it is best to import these modules qualified._
 
-_Note: there is no `System.IO.Utf8.readFile` because it’s 2020 and
+_Note: there is no `System.IO.Utf8.readFile` because it’s 2024 and
 you should not read `String`s from files._
 
 All these functions will make sure that the content will be treated as if it
@@ -72,6 +74,8 @@ doSomethingWithAFile h = Utf8.withhandle h $ do
 When writing a file either open it using `withFile`/`openFile` from
 `System.IO.Utf8` or write to it directly with `writeFile` from
 `Data.Text.IO.Utf8`.
+Starting from `text-2.1`, `Data.Text.IO.Utf8` is available in the `text` package
+itself, hence this module in `with-utf8` is now deprecated.
 
 _Note: it is best to import these modules qualified._
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
 
         hs-package-name = "with-utf8";
 
-        ghc-versions = [ "884" "8107" "902" "928" "948" ];
+        ghc-versions = [ "884" "8107" "902" "928" "948" "963" "981" ];
 
         # invoke haskell.nix for each ghc version listed in ghc-versions
         pkgs-per-ghc = lib.genAttrs (map (v: "ghc${v}") ghc-versions)

--- a/lib/Data/Text/IO/Utf8.hs
+++ b/lib/Data/Text/IO/Utf8.hs
@@ -8,6 +8,7 @@
 -- Wrappers around simple file reading/writing functions from the
 -- @text@ package that reset the handle encoding to UTF-8.
 module Data.Text.IO.Utf8
+  {-# DEPRECATED "Use Data.Text.IO.Utf8 from the text package instead" #-}
   ( readFile
   , writeFile
   ) where

--- a/package.yaml
+++ b/package.yaml
@@ -37,8 +37,8 @@ ghc-options:
   - -Wredundant-constraints
 
 dependencies:
-  - base >= 4.10 && < 4.19
-  - text >= 0.7 && < 2.1
+  - base >= 4.10 && < 4.20
+  - text >= 0.7 && < 2.2
 
 library:
   source-dirs: lib

--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 name: with-utf8
-version: 1.0.2.4
+version: 1.1.0.0
 synopsis: Get your IO right on the first try
 description: |
   This minimalistic library helps you navigate the world of text encodings

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,20 +2,5 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-resolver: lts-18.14
+resolver: lts-22.5
 packages: [.]
-
-extra-deps:
-  # Required for GHC >= 9
-  - th-env-0.1.0.3
-
-  # Required for GHC >= 9.2
-  - constraints-0.13.1
-  - hashable-1.3.5.0
-  - random-1.2.1
-
-  # text-2.0
-  #- hashable-1.4.0.1
-  #- text-2.0
-
-#allow-newer: true  # text-2.0: some of our deps (incorrectly) say they don’t like it

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,38 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: th-env-0.1.0.3@sha256:3804eeff3edf8b4c3c6ca68a8b4eff3bf23c07c468c699e3f010c4dec1603830,1386
-    pantry-tree:
-      size: 370
-      sha256: f14846f743126dde54c05cb7eb3038b059bec372532582858ca982bdebef0bad
-  original:
-    hackage: th-env-0.1.0.3
-- completed:
-    hackage: constraints-0.13.1@sha256:3d2002767a32e0c0ea156276c34de926875817c4db385d8e75776b6e35b0267d,2396
-    pantry-tree:
-      size: 867
-      sha256: a4d80e46d52971b0f74051c3cc2a7e87408b6e1e19b5fb4814360441c9e524a0
-  original:
-    hackage: constraints-0.13.1
-- completed:
-    hackage: hashable-1.3.5.0@sha256:47d1232d9788bb909cfbd80618de18dcdfb925609593e202912bd5841db138c1,4193
-    pantry-tree:
-      size: 1248
-      sha256: adde5ecc080faa094750544837937cf876e65bf5bf28d81db22e7401faa46bf3
-  original:
-    hackage: hashable-1.3.5.0
-- completed:
-    hackage: random-1.2.1@sha256:8bee24dc0c985a90ee78d94c61f8aed21c49633686f0f1c14c5078d818ee43a2,6598
-    pantry-tree:
-      size: 1528
-      sha256: 8bdc994ce41f43624ab42302a881fe5a0f81d965f5d238841e24943664681a06
-  original:
-    hackage: random-1.2.1
+packages: []
 snapshots:
 - completed:
-    size: 586069
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/14.yaml
-    sha256: 87842ecbaa8ca9cee59a7e6be52369dbed82ed075cb4e0d152614a627e8fd488
-  original: lts-18.14
+    sha256: 90e6fcdcf6706918ef022ab01214828c550ee637a2d50f4fe96b15742b8bced1
+    size: 714102
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/5.yaml
+  original: lts-22.5

--- a/test/Test/Utf8/ReadWrite.hs
+++ b/test/Test/Utf8/ReadWrite.hs
@@ -8,6 +8,10 @@
 {-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- Due to our Data.Text.IO.Utf8 which is deprecated and
+-- will be removed later.
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 module Test.Utf8.ReadWrite where
 
 import Control.DeepSeq (force)

--- a/test/Test/Utf8/ReadWrite.hs
+++ b/test/Test/Utf8/ReadWrite.hs
@@ -5,6 +5,7 @@
 
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Utf8.ReadWrite where
@@ -22,7 +23,7 @@ import Hedgehog (Property, forAll, property, (===))
 import Test.HUnit (Assertion, assertFailure)
 
 import qualified Data.Text.IO as T
-import qualified Data.Text.IO.Utf8 as Utf8
+import qualified "with-utf8" Data.Text.IO.Utf8 as Utf8
 import qualified System.IO as IO
 import qualified System.IO.Utf8 as Utf8
 

--- a/with-utf8.cabal
+++ b/with-utf8.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           with-utf8
-version:        1.0.2.4
+version:        1.1.0.0
 synopsis:       Get your IO right on the first try
 description:    This minimalistic library helps you navigate the world of text encodings
                 avoiding @invalid argument (invalid byte sequence)@

--- a/with-utf8.cabal
+++ b/with-utf8.cabal
@@ -48,9 +48,9 @@ library
       lib
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
-      base >=4.10 && <4.19
+      base >=4.10 && <4.20
     , safe-exceptions ==0.1.*
-    , text >=0.7 && <2.1
+    , text >=0.7 && <2.2
   default-language: Haskell2010
 
 executable utf8-troubleshoot
@@ -63,12 +63,12 @@ executable utf8-troubleshoot
   c-sources:
       app/utf8-troubleshoot/cbits/locale.c
   build-depends:
-      base >=4.10 && <4.19
+      base >=4.10 && <4.20
     , directory >=1.2.5.0 && <1.4
     , filepath >=1.0 && <1.5
     , process >=1.0.1.1 && <1.7
     , safe-exceptions
-    , text >=0.7 && <2.1
+    , text >=0.7 && <2.2
     , th-env >=0.1.0.0 && <0.2
   default-language: Haskell2010
 
@@ -89,7 +89,7 @@ test-suite with-utf8-test
       tasty-discover:tasty-discover
   build-depends:
       HUnit
-    , base >=4.10 && <4.19
+    , base >=4.10 && <4.20
     , deepseq
     , hedgehog
     , safe-exceptions
@@ -97,7 +97,7 @@ test-suite with-utf8-test
     , tasty-hedgehog
     , tasty-hunit
     , temporary
-    , text >=0.7 && <2.1
+    , text >=0.7 && <2.2
     , unix
     , with-utf8
   default-language: Haskell2010


### PR DESCRIPTION
1. Update `text` and `base` versions to support GHC-9.8.
2. Test with GHC-9.{6,8} on CI.
3. Update Stackage resolver while we are at it.

Originally started here: https://github.com/serokell/haskell-with-utf8/pull/25